### PR TITLE
Clean-up duplicate jobs

### DIFF
--- a/ckanext/harvest/logic/action/create.py
+++ b/ckanext/harvest/logic/action/create.py
@@ -103,7 +103,7 @@ def harvest_job_create(context, data_dict):
     job.source = source
 
     job.save()
-    log.info('Harvest job saved %s', job.id)
+    log.info('Harvest job created id=%s', job.id)
 
     if run_it:
         toolkit.get_action('harvest_send_job_to_gather_queue')(

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -455,13 +455,12 @@ def harvest_jobs_run(context,data_dict):
 
     # Abort any duplicate jobs
     # (There shouldn't be any in theory but they do crop up)
-    running_jobs_q = session.query(HarvestJob)
+    query = session.query(HarvestJob)
     if source_id:
-        running_jobs_q = running_jobs_q.filter(HarvestJob.source_id==source_id)
-    running_jobs_q = running_jobs_q.filter(HarvestJob.status=='Running') \
+        query = query.filter(HarvestJob.source_id == source_id)
+    query = query.filter(HarvestJob.status == 'Running') \
         .order_by(HarvestJob.created.desc())
-    running_jobs = running_jobs_q.all()
-
+    running_jobs = query.all()
     # iterate over the sources
     def get_source(job):
         return job.source_id

--- a/ckanext/harvest/logic/action/update.py
+++ b/ckanext/harvest/logic/action/update.py
@@ -23,9 +23,13 @@ from ckanext.harvest.queue import get_gather_publisher, resubmit_jobs
 from ckanext.harvest.model import (HarvestSource, HarvestJob, HarvestObject)
 from ckanext.harvest.logic import HarvestJobExists
 from ckanext.harvest.logic.schema import default_harvest_source_schema
+from ckanext.harvest.logic.dictization import (harvest_source_dictize,
+                                               harvest_job_dictize)
 
 from ckanext.harvest.logic.action.create import _error_summary
-from ckanext.harvest.logic.action.get import harvest_source_show, harvest_job_list, get_sources
+from ckanext.harvest.logic.action.get import (harvest_source_show,
+                                              harvest_job_list,
+                                              get_sources)
 from ckanext.harvest import lib as harvest_lib
 
 

--- a/ckanext/harvest/queue.py
+++ b/ckanext/harvest/queue.py
@@ -112,6 +112,12 @@ def gather_callback(message_data, message):
             if not job:
                 log.error('Harvest job does not exist: %s' % id)
                 return
+            if job.status != 'Running':
+                if job.status == 'Aborted':
+                    log.info('Harvest job has been aborted: %s' % id)
+                else:
+                    log.error('Harvest job is wrong state: %s' % id)
+                return
 
             # Send the harvest job to the plugins that implement
             # the Harvester interface, only if the source type

--- a/ckanext/harvest/queue.py
+++ b/ckanext/harvest/queue.py
@@ -110,13 +110,17 @@ def gather_callback(message_data, message):
     try:
         try:
             if not job:
-                log.error('Harvest job does not exist: %s' % id)
+                log.error('Harvest job does not exist: %s', id)
                 return
+
             if job.status != 'Running':
                 if job.status == 'Aborted':
-                    log.info('Harvest job has been aborted: %s' % id)
+                    log.info('Harvest job has been aborted: %s', id)
                 else:
-                    log.error('Harvest job is wrong state: %s' % id)
+                    log.error('Harvest job invalid - '
+                              'status should be "Running" but was %s '
+                              'id=%s created=%s',
+                              job.status, id, str(job.created))
                 return
 
             # Send the harvest job to the plugins that implement


### PR DESCRIPTION
These were appearing because of the bug allowing you to start multiple jobs on a source if you specified the name. This was solved, but it's good to clean them up, in case they appear again somehow.
