### PR TITLE
Fix broken ckan harvester

### DIFF
--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -58,7 +58,7 @@ class CKANHarvester(DguHarvesterBase):
         except httplib.HTTPException, e:
             raise ContentFetchError('HTTP Exception: %s' % e)
 
-        return http_request
+        return http_request.text
 
     def _get_group(self, base_url, group_name):
         url = base_url + self._get_rest_api_offset() + '/group/' + munge_name(group_name)

--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -606,9 +606,11 @@ class CKANHarvester(DguHarvesterBase):
             licence = None
             if not license_obj:
                 # license_id not known to this CKAN, so identify by title
+                # title can be None, but we need a string, which is why this
+                # isn't `package_dict.get('license_title', '')`
                 license_id, licence = \
                     dgu_helpers.get_licence_fields_from_free_text(
-                        package_dict.get('license_title', ''))
+                        package_dict.get('license_title') or '')
                 package_dict['license_id'] = license_id
                 if licence:
                     package_dict['extras']['licence'] = licence


### PR DESCRIPTION
Harvesting from remote CKAN instances is currently broken.  There are two problems:

1. In the change from urllib to requests, the `_get_content` function was changed to return a `Response` object, not a string as previously expected.

2. The `package_dict['license_title']` field can now be `None`.  This may be related to the urllib/requests change, but I'm not certain.

---

The travis build is failing for unrelated reasons:

```
+sudo apt-get install postgresql-9.1 solr-jetty libcommons-fileupload-java:amd64=1.2.2-1
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Version '1.2.2-1' for 'libcommons-fileupload-java' was not found
```